### PR TITLE
Fix form collection create_existing_subform when more than 10 elements

### DIFF
--- a/lib/formex/form_collection.ex
+++ b/lib/formex/form_collection.ex
@@ -101,7 +101,9 @@ defmodule Formex.FormCollection do
     substructs
     |> Enum.map(fn substruct ->
       {_, subparams} =
-        Enum.find(params, {nil, %{}}, fn {_k, v} ->
+        params
+        |> Enum.filter(fn {_key, val} -> val["id"] end)
+        |> Enum.find({nil, %{}}, fn {k, v} ->
           id =
             if is_integer(substruct.id) do
               v["id"] |> Integer.parse() |> elem(0)


### PR DESCRIPTION
The creation of subforms wasn't filtering the new params which doesn't contain any `id` yet. The issue was present only when a form had 10 elements and we were trying to add a new element because of the order of the params.

*Example with a 10th value added, seen at the end of the params*
```elixir
%{
  "base_form_custom_field" => "value"
  "sub_form_example" => %{
    "0" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "4"
    },
    "1" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "5"
    },
    "2" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "6"
    },
    "3" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "7"
    },
    "4" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "17"
    },
    "5" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "18"
    },
    "6" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "12"
    },
    "7" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "21"
    },
    "8" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "24"
    },
    "9" => %{
      "formex_id" => "d908daf1-5c73-4a37-8804-14edefe8d33b",
      "custom_field" => "random value",
    }
  }
}
```

*Example when adding the 10th. It is found at position 2 of the list because of "10" string ID*
```elixir
%{
  "base_form_custom_field" => "value"
  "sub_form_example" => %{
    "0" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "4"
    },
    "1" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "5"
    },
    "10" => %{
      "formex_id" => "d908daf1-5c73-4a37-8804-14edefe8d33a",
      "custom_field" => "random value",
    },
    "2" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "6"
    },
    "3" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "7"
    },
    "4" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "17"
    },
    "5" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "18"
    },
    "6" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "12"
    },
    "7" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "21"
    },
    "8" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "24"
    },
    "9" => %{
      "custom_field" => "random value",
      "formex_delete" => "",
      "id" => "14"
    }
  }
}
```